### PR TITLE
hotfix/inactive-step-label-color

### DIFF
--- a/src/components/StepperCounter.vue
+++ b/src/components/StepperCounter.vue
@@ -176,4 +176,8 @@ export default {
     .cursor_pointer {
         cursor: pointer;
     }
+
+    .not_active_step_label {
+        color: #5d6369;
+    }
 </style>

--- a/src/components/StepperCounter.vue
+++ b/src/components/StepperCounter.vue
@@ -53,7 +53,10 @@
                 />
 
             </div>
-            <div class="label-container mt-2">
+            <div
+                class="label-container mt-2"
+                :class="!step.active ? 'not_active_step_label' : ''"
+            >
                 <small>{{ step.label }}</small>
             </div>
         </div>

--- a/src/components/StepperCounter.vue
+++ b/src/components/StepperCounter.vue
@@ -3,7 +3,7 @@
         <div
             v-for="(step, index) in steps"
             :key="index"
-            class="w-100"
+            :class="index !== steps.length - 1 ? 'w-100' : ''"
         >
             <div
                 class="d-flex align-items-center"

--- a/src/components/StepperCounter.vue
+++ b/src/components/StepperCounter.vue
@@ -11,19 +11,19 @@
                 @click="changeStep(index)"
             >
                 <div
-                    class="d-flex justify-content-center align-items-center cursor_pointer"
+                    class="d-flex justify-content-center align-items-center cursor-pointer"
                     :class="circleStyle(step)"
                 >
                     <span
                         v-if="!step.concluded"
-                        class="not_concluded_step_text_color fs-14"
+                        class="not-concluded-step-text-color fs-14"
                     >
                         {{ index + 1 }}
                     </span>
                     <check-icon
                         v-else
                         size="1x"
-                        class="concluded_step"
+                        class="concluded-step"
                     />
                 </div>
 
@@ -33,7 +33,7 @@
                         steps[index].concluded &&
                         steps[index + 1].concluded
                     "
-                    class="concluded_stepper_divider"
+                    class="concluded-stepper-divider"
                 />
                 <div 
                     v-else-if="
@@ -45,17 +45,17 @@
                         index === 0 &&
                         steps[index].concluded)
                     "
-                    class="in_progress_stepper_divider"
+                    class="in-progress-stepper-divider"
                 />
                 <div 
                     v-else-if="index !== steps.length - 1"
-                    class="common_stepper_divider"
+                    class="common-stepper-divider"
                 />
 
             </div>
             <div
                 class="label-container mt-2"
-                :class="!step.active ? 'not_active_step_label' : ''"
+                :class="!step.active ? 'not-active-step-label' : ''"
             >
                 <small>{{ step.label }}</small>
             </div>
@@ -87,15 +87,15 @@ export default {
             let style = '';
 
             if (step.concluded) {
-                style += 'concluded_step';
+                style += 'concluded-step';
             } 
             
             if (step.active){
-                style += 'active_step';
+                style += 'active-step';
             }
 
             if (!step.active && !step.concluded) {
-                style += ' not_active_step';
+                style += ' not-active-step';
             }
 
             return style;
@@ -113,7 +113,7 @@ export default {
 }
 </script>
 <style>
-    .active_step, .not_active_step, .concluded_step {
+    .active-step, .not-active-step, .concluded-step {
         border-radius: 50px;
         min-width: 30px;
         min-height: 30px;
@@ -121,44 +121,44 @@ export default {
         border-style: solid;
     }
 
-    .active_step {
+    .active-step {
         border-color: #00CBAD;
     }
 
-    .concluded_step { 
+    .concluded-step { 
         background-color: #00CBAD;
         border-color: #00CBAD;
         width: 30px;
         height: 30px;
     }
 
-    .not_active_step {
+    .not-active-step {
         color: #BFC2C5;
         border-color: #BFC2C5;
     }
 
-    .not_concluded_step_text_color {
+    .not-concluded-step-text-color {
         color: #00CBAD;
     }
 
-    .common_stepper_divider, .in_progress_stepper_divider, .concluded_stepper_divider {
+    .common-stepper-divider, .in-progress-stepper-divider, .concluded-stepper-divider {
         height: 3px;
         width: 100%;
     }
 
-    .common_stepper_divider {
+    .common-stepper-divider {
         background-color: #BFC2C5;
     }
 
-    .in_progress_stepper_divider {
+    .in-progress-stepper-divider {
         background: linear-gradient(90deg, #43E4CC 0%, #BFC2C5 67.57%);
     }
 
-    .concluded_stepper_divider {
+    .concluded-stepper-divider {
         background: #00CBAD;
     }
 
-    .concluded_step {
+    .concluded-step {
         color: #fff;
     }
 
@@ -173,11 +173,11 @@ export default {
         font-size: 14px;
     }
 
-    .cursor_pointer {
+    .cursor-pointer {
         cursor: pointer;
     }
 
-    .not_active_step_label {
+    .not-active-step-label {
         color: #5d6369;
     }
 </style>

--- a/test/unit/StepperCounter.spec.js
+++ b/test/unit/StepperCounter.spec.js
@@ -35,7 +35,7 @@ describe("Divider styles test", () => {
 				steps: mocked_data,
 			},
 		});
-		expect(wrapper.findAll('.common_stepper_divider').length).toBe(2);
+		expect(wrapper.findAll('.common-stepper-divider').length).toBe(2);
 	});
 
 	test('if one of the stepper divider is rendered as an in_progress divider and others are rendered as common dividers', () => {
@@ -51,8 +51,8 @@ describe("Divider styles test", () => {
 				steps: mocked_data,
 			},
 		});
-		expect(wrapper.findAll('.in_progress_stepper_divider').length).toBe(1);
-		expect(wrapper.findAll('.common_stepper_divider').length).toBe(1);
+		expect(wrapper.findAll('.in-progress-stepper-divider').length).toBe(1);
+		expect(wrapper.findAll('.common-stepper-divider').length).toBe(1);
 	});
 
 	test('if one of the stepper divider is rendered as a concluded divider and the other is rendered as an in_progress divider', () => {
@@ -68,8 +68,8 @@ describe("Divider styles test", () => {
 				steps: mocked_data,
 			},
 		});
-		expect(wrapper.findAll('.concluded_stepper_divider').length).toBe(1);
-		expect(wrapper.findAll('.in_progress_stepper_divider').length).toBe(1);
+		expect(wrapper.findAll('.concluded-stepper-divider').length).toBe(1);
+		expect(wrapper.findAll('.in-progress-stepper-divider').length).toBe(1);
 	});
 });
 

--- a/test/unit/__snapshots__/StepperCounter.spec.js.snap
+++ b/test/unit/__snapshots__/StepperCounter.spec.js.snap
@@ -9,7 +9,7 @@ exports[`Component is mounted properly 1`] = `
         </svg></div>
       <div class="in_progress_stepper_divider"></div>
     </div>
-    <div class="label-container mt-2"><small>Dummy label 1</small></div>
+    <div class="label-container mt-2 not_active_step_label"><small>Dummy label 1</small></div>
   </div>
   <div class="w-100">
     <div id="step-2" class="d-flex align-items-center">
@@ -20,14 +20,14 @@ exports[`Component is mounted properly 1`] = `
     </div>
     <div class="label-container mt-2"><small>Dummy label 3</small></div>
   </div>
-  <div class="w-100">
+  <div class="">
     <div id="step-3" class="d-flex align-items-center">
       <div class="d-flex justify-content-center align-items-center cursor_pointer  not_active_step"><span class="not_concluded_step_text_color fs-14">
                     3
                 </span></div>
       <!---->
     </div>
-    <div class="label-container mt-2"><small>Dummy label 2</small></div>
+    <div class="label-container mt-2 not_active_step_label"><small>Dummy label 2</small></div>
   </div>
 </div>
 `;

--- a/test/unit/__snapshots__/StepperCounter.spec.js.snap
+++ b/test/unit/__snapshots__/StepperCounter.spec.js.snap
@@ -4,30 +4,30 @@ exports[`Component is mounted properly 1`] = `
 <div class="d-flex justify-content-between">
   <div class="w-100">
     <div id="step-1" class="d-flex align-items-center">
-      <div class="d-flex justify-content-center align-items-center cursor_pointer concluded_step"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="concluded_step feather feather-check">
+      <div class="d-flex justify-content-center align-items-center cursor-pointer concluded-step"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="concluded-step feather feather-check">
           <polyline points="20 6 9 17 4 12"></polyline>
         </svg></div>
-      <div class="in_progress_stepper_divider"></div>
+      <div class="in-progress-stepper-divider"></div>
     </div>
-    <div class="label-container mt-2 not_active_step_label"><small>Dummy label 1</small></div>
+    <div class="label-container mt-2 not-active-step-label"><small>Dummy label 1</small></div>
   </div>
   <div class="w-100">
     <div id="step-2" class="d-flex align-items-center">
-      <div class="d-flex justify-content-center align-items-center cursor_pointer active_step"><span class="not_concluded_step_text_color fs-14">
+      <div class="d-flex justify-content-center align-items-center cursor-pointer active-step"><span class="not-concluded-step-text-color fs-14">
                     2
                 </span></div>
-      <div class="common_stepper_divider"></div>
+      <div class="common-stepper-divider"></div>
     </div>
     <div class="label-container mt-2"><small>Dummy label 3</small></div>
   </div>
   <div class="">
     <div id="step-3" class="d-flex align-items-center">
-      <div class="d-flex justify-content-center align-items-center cursor_pointer  not_active_step"><span class="not_concluded_step_text_color fs-14">
+      <div class="d-flex justify-content-center align-items-center cursor-pointer  not-active-step"><span class="not-concluded-step-text-color fs-14">
                     3
                 </span></div>
       <!---->
     </div>
-    <div class="label-container mt-2 not_active_step_label"><small>Dummy label 2</small></div>
+    <div class="label-container mt-2 not-active-step-label"><small>Dummy label 2</small></div>
   </div>
 </div>
 `;


### PR DESCRIPTION
Fixes #
#### What is the purpose of this pull request?
To fix the layout behaviour of the stepper counter that cuased it to have a right margin, and to change the label color of the inactive steps

#### How should this be manually tested?
See how it works interactign with it and with the addons

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/20057968/70648570-1b460800-1c2a-11ea-90e4-ada91c659e0e.png)

#### Types of changes
- [ ]  New feature (a change which adds functionality)
- [x] Hot fix (a change which fixes an issue found in the master branch)
- [ ]  Documentation change