### PR TITLE
feature/improve-badge-contrast-ratios-and-enhance-funcionality

### DIFF
--- a/src/components/Badge.stories.js
+++ b/src/components/Badge.stories.js
@@ -70,13 +70,28 @@ export const badge = () => ({
 		text: {
 			default: () => text('Label text:', 'Negative'),
 		},
-		status_type: {
-			default: () => select('Status type', {
-				Negative: 'Negative',
-				Positive: 'Positive',
-				Neutral: 'Neutral',
-			}, 'Negative'),
+		bgColor: {
+			default: () => text('Background color:', '#dc354526')
 		},
+		color: {
+			default: () => text('Color:', '#dc3545')
+		},
+		variant: {
+			default: () => select('Variant', {
+				variant1: 'variant-1',
+				variant2: 'variant-2',
+				variant3: 'variant-3',
+				variant4: 'variant-4',
+				variant5: 'variant-5',
+				variant6: 'variant-6',
+			}, 'variant-1'),
+		},
+		variantMode: {
+			default: () => boolean('Variant Mode', true)
+		},
+		colorCodeMode: {
+			default: () => boolean('Color Code Mode', false)
+		}
 	},
 	template:
 		`<s-badge

--- a/src/components/Badge.stories.js
+++ b/src/components/Badge.stories.js
@@ -12,7 +12,6 @@ const template = `
 	:color="color"
 	:bgColor="bgColor"
 	:content="text"
-	:variantMode="variantMode"
 	:variant="variant"
 	:colorCodeMode="colorCodeMode"
 />`;

--- a/src/components/Badge.stories.js
+++ b/src/components/Badge.stories.js
@@ -2,7 +2,7 @@
 import { withA11y } from '@storybook/addon-a11y';
 import { withDesign } from 'storybook-addon-designs';
 import {
-	withKnobs, text, select,
+	withKnobs, text, select, boolean,
 } from '@storybook/addon-knobs';
 
 import Badge from './Badge.vue';

--- a/src/components/Badge.stories.js
+++ b/src/components/Badge.stories.js
@@ -9,8 +9,12 @@ import Badge from './Badge.vue';
 
 const template = `
 <s-badge
-	status_type="Negative"
-	content="Negativo"
+	:color="color"
+	:bgColor="bgColor"
+	:content="text"
+	:variantMode="variantMode"
+	:variant="variant"
+	:colorCodeMode="colorCodeMode"
 />`;
 
 const componentDescription = 'Badges are small status descriptors used, primarly, to highlight important metadata about features or content.';
@@ -93,10 +97,5 @@ export const badge = () => ({
 			default: () => boolean('Color Code Mode', false)
 		}
 	},
-	template:
-		`<s-badge
-			:status_type="status_type"
-			:content="text"
-		>
-		</s-badge>`,
+	template: template,
 });

--- a/src/components/Badge.stories.js
+++ b/src/components/Badge.stories.js
@@ -30,7 +30,7 @@ const docsDecorator = () => {
 					<div slot="usage">
 						<h5>Use Badges when:</h5>
 						<ul>
-							<li>You want to show, in a visual way, associated with your logic business or users actions</li>
+							<li>You want to show status associated with your logic business or users actions</li>
 							<li>You want to highlight important metadata about features or content</li>
 							<li>You need to show information that is helpful but needs the surrounding context to make sense (status,type, etc.)</li>
 							<li>The badge is readonly</li>

--- a/src/components/Badge.stories.js
+++ b/src/components/Badge.stories.js
@@ -82,13 +82,13 @@ export const badge = () => ({
 		},
 		variant: {
 			default: () => select('Variant', {
-				variant1: 'variant-1',
-				variant2: 'variant-2',
-				variant3: 'variant-3',
-				variant4: 'variant-4',
-				variant5: 'variant-5',
-				variant6: 'variant-6',
-			}, 'variant-1'),
+				yellow: 'yellow',
+				green: 'green',
+				red: 'red',
+				blue: 'blue',
+				purple: 'purple',
+				gray: 'gray',
+			}, 'yellow'),
 		},
 		variantMode: {
 			default: () => boolean('Variant Mode', true)

--- a/src/components/Badge.stories.js
+++ b/src/components/Badge.stories.js
@@ -90,9 +90,6 @@ export const badge = () => ({
 				gray: 'gray',
 			}, 'yellow'),
 		},
-		variantMode: {
-			default: () => boolean('Variant Mode', true)
-		},
 		colorCodeMode: {
 			default: () => boolean('Color Code Mode', false)
 		}

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -107,6 +107,8 @@ export default {
 .badge-container {
 	border-radius: 8px !important;
 	width: fit-content;
+	background-color: var(--bg-color);
+	color: var(--color);
 }
 
 .variant-1 {

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -33,6 +33,36 @@ export default {
 				you can pass the hex value of the text
 				color of the badge.`,
 	},
+		bgColor: {
+			type: String,
+			default: '#28a74526',
+			description: `If the color code mode is set,
+				you can pass the hex value of the background
+				color of the badge.`,
+		},
+		variantMode: {
+			type: Boolean,
+			default: true,
+			description: `The property that specifies 
+				if the badge will work in variant mode
+				or not.`,
+		},
+		colorCodeMode: {
+			type: Boolean,
+			default: false,
+			description: `The property that specifies 
+				if the badge will work in the color code
+				mode or not.`,
+		},
+		variant: {
+			type: String,
+			default: 'variant-1',
+			description: `Variant mode gives 6 predefined badges 
+				to work with. Seting this property to 'true',
+				you can use 'variant-1', 'variant-2', ... 'variant-6'
+				to use the predefined badge styles.`,
+		},
+	},
 
 	computed: {
 		style() {

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -50,10 +50,10 @@ export default {
 		},
 		variant: {
 			type: String,
-			default: 'variant-1',
+			default: 'yellow',
 			description: `Variant mode gives 6 predefined badges 
 				to work with. Seting this property to 'true',
-				you can use 'variant-1', 'variant-2', ... 'variant-6'
+				you can use 'yellow', 'green', ... 'gray'
 				to use the predefined badge styles.`,
 		},
 	},
@@ -62,26 +62,26 @@ export default {
 		predefinedStyle() {
 			let computed_style = '';
 			switch (this.variant) {
-				case 'variant-1':
-					computed_style = 'variant-1';
+				case 'yellow':
+					computed_style = 'yellow';
 					break;
-				case 'variant-2':
-					computed_style = 'variant-2';
+				case 'green':
+					computed_style = 'green';
 					break;
-				case 'variant-3':
-					computed_style = 'variant-3';
+				case 'red':
+					computed_style = 'red';
 					break;
-				case 'variant-4':
-					computed_style = 'variant-4';
+				case 'blue':
+					computed_style = 'blue';
 					break;
-				case 'variant-5':
-					computed_style = 'variant-5';
+				case 'purple':
+					computed_style = 'purple';
 					break;
-				case 'variant-6':
-					computed_style = 'variant-6';
+				case 'gray':
+					computed_style = 'gray';
 					break;
 				default:
-					computed_style = 'variant-1';
+					computed_style = 'yellow';
 					break;
 			}
 
@@ -105,32 +105,32 @@ export default {
 	color: var(--color);
 }
 
-.variant-1 {
+.yellow {
 	color: #5a4300;
 	background-color: #ffbf004d;
 }
 
-.variant-2 {
+.green {
 	color: #005a15;
 	background-color: #28a74526;
 }
 
-.variant-3 {
+.red {
 	color: #8c1520;
 	background-color: #e2757f40;
 }
 
-.variant-4 {
+.blue {
 	color: #00469c;
 	background-color: #60c4ff40;
 }
 
-.variant-5 {
+.purple {
 	color: #621e83;
 	background-color: #e47aff40;
 }
 
-.variant-6 {
+.gray {
 	color: #2f2f2f;
 	background-color: #acacac40;
 }

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -95,8 +95,8 @@ export default {
 	background-color: #ffbf004d;
 }
 
-.positive-badge {
-	color: #28A745;
+.variant-2 {
+	color: #005a15;
 	background-color: #28a74526;
 }
 

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -14,13 +14,6 @@
 
 export default {
 	props: {
-		status_type: {
-			type: String,
-			default: 'Negative',
-			description: `A status that defines the color of the badge that will be redered.
-				The options are: 'Negative', 'Neutral', and 'Positive'`,
-			required: false,
-		},
 		content: {
 			type: String,
 			default: 'Negativo',
@@ -33,7 +26,7 @@ export default {
 			description: `If the color code mode is set,
 				you can pass the hex value of the text
 				color of the badge.`,
-	},
+		},
 		bgColor: {
 			type: String,
 			default: '#28a74526',

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -2,7 +2,7 @@
 	<div
 		class="badge-container px-3 d-flex justify-content-center"
 		:style="colorCodeMode ? styleVariables : ''"
-		:class="variantMode ? predefinedStyle : ''"
+		:class="!colorCodeMode ? predefinedStyle : ''"
 	>
 		<small class="regular">
 			{{ content }}
@@ -33,13 +33,6 @@ export default {
 			description: `If the color code mode is set,
 				you can pass the hex value of the background
 				color of the badge.`,
-		},
-		variantMode: {
-			type: Boolean,
-			default: true,
-			description: `The property that specifies 
-				if the badge will work in variant mode
-				or not.`,
 		},
 		colorCodeMode: {
 			type: Boolean,

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -67,9 +67,21 @@ export default {
 	computed: {
 		style() {
 			let computed_style = '';
-			switch (this.status_type) {
-				case 'Neutral':
-					computed_style = 'neutral-badge';
+			switch (this.variant) {
+				case 'variant-1':
+					computed_style = 'variant-1';
+					break;
+				case 'variant-2':
+					computed_style = 'variant-2';
+					break;
+				case 'variant-3':
+					computed_style = 'variant-3';
+					break;
+				case 'variant-4':
+					computed_style = 'variant-4';
+					break;
+				case 'variant-5':
+					computed_style = 'variant-5';
 					break;
 				case 'Positive':
 					computed_style = 'positive-badge';

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -26,6 +26,12 @@ export default {
 			description: 'The text that will be displayed inside the badge.',
 			required: true,
 		},
+		color: {
+			type: String,
+			default: '#28A745',
+			description: `If the color code mode is set,
+				you can pass the hex value of the text
+				color of the badge.`,
 	},
 
 	computed: {

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -1,7 +1,8 @@
 <template>
 	<div
 		class="badge-container px-3 d-flex justify-content-center"
-		:class="style"
+		:style="colorCodeMode ? styleVariables : ''"
+		:class="variantMode ? predefinedStyle : ''"
 	>
 		<small class="regular">
 			{{ content }}

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -90,9 +90,9 @@ export default {
 	width: fit-content;
 }
 
-.neutral-badge {
-	color: #efb300;
-	background-color: #ffc10726;
+.variant-1 {
+	color: #5a4300;
+	background-color: #ffbf004d;
 }
 
 .positive-badge {

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -88,7 +88,7 @@ export default {
 					computed_style = 'variant-6';
 					break;
 				default:
-					computed_style = 'negative-badge';
+					computed_style = 'variant-1';
 					break;
 			}
 

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -84,8 +84,8 @@ export default {
 				case 'variant-5':
 					computed_style = 'variant-5';
 					break;
-				case 'Positive':
-					computed_style = 'positive-badge';
+				case 'variant-6':
+					computed_style = 'variant-6';
 					break;
 				default:
 					computed_style = 'negative-badge';

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -100,8 +100,23 @@ export default {
 	background-color: #28a74526;
 }
 
-.negative-badge {
-	color: #dc3545;
-	background-color: #dc354526;
+.variant-3 {
+	color: #8c1520;
+	background-color: #e2757f40;
+}
+
+.variant-4 {
+	color: #00469c;
+	background-color: #60c4ff40;
+}
+
+.variant-5 {
+	color: #621e83;
+	background-color: #e47aff40;
+}
+
+.variant-6 {
+	color: #2f2f2f;
+	background-color: #acacac40;
 }
 </style>

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -66,7 +66,7 @@ export default {
 	},
 
 	computed: {
-		style() {
+		predefinedStyle() {
 			let computed_style = '';
 			switch (this.variant) {
 				case 'variant-1':

--- a/src/components/Badge.vue
+++ b/src/components/Badge.vue
@@ -93,6 +93,13 @@ export default {
 
 			return computed_style;
 		},
+
+		styleVariables() {
+			return {
+				'--bg-color': this.bgColor,
+				'--color': this.color,
+			};
+		},
 	},
 };
 </script>

--- a/src/components/Wrapper.vue
+++ b/src/components/Wrapper.vue
@@ -146,7 +146,7 @@ export default {
 			formattedProp.name = _.keys(this.componentData.props)[index];
 			formattedProp.type = item.type.name || '--';
 			formattedProp.required = item.required || false;
-			formattedProp.defaultValue = item.default || '--';
+			formattedProp.defaultValue = item.default === false ? false : (item.default || '--');
 			formattedProp.description = item.description || '--';
 
 			this.formattedProps.push(formattedProp);

--- a/test/unit/Badge.spec.js
+++ b/test/unit/Badge.spec.js
@@ -107,7 +107,6 @@ describe("Prop 'bgColor' and 'color' tests", () => {
 			localVue,
 			propsData: {
 				colorCodeMode: true,
-				variantMode: false,
 				color: 'white',
 				bgColor: 'blue',
 				content: 'Test',

--- a/test/unit/Badge.spec.js
+++ b/test/unit/Badge.spec.js
@@ -23,81 +23,81 @@ describe("Computed property 'predefinedStyle' test", () => {
 				content: 'Test',
 			},
 		});
-		expect(wrapper.vm.predefinedStyle).toBe('variant-1');
+		expect(wrapper.vm.predefinedStyle).toBe('yellow');
 	});
 });
 
 describe("Prop 'variant' tests", () => {
-	test("if the computed property changes when the prop variant is setted to 'variant-1'", () => {
+	test("if the computed property changes when the prop variant is setted to 'yellow'", () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
-				variant: 'variant-1',
+				variant: 'yellow',
 				content: 'Test',
 			},
 		});
 
-		expect(wrapper.vm.predefinedStyle).toBe('variant-1');
+		expect(wrapper.vm.predefinedStyle).toBe('yellow');
 	});
 
-	test("if the computed property changes when the prop variant is setted to 'variant-2'", () => {
+	test("if the computed property changes when the prop variant is setted to 'green'", () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
-				variant: 'variant-2',
+				variant: 'green',
 				content: 'Test',
 			},
 		});
 
-		expect(wrapper.vm.predefinedStyle).toBe('variant-2');
+		expect(wrapper.vm.predefinedStyle).toBe('green');
 	});
 
-	test("if the computed property changes when the prop variant is setted to 'variant-3'", () => {
+	test("if the computed property changes when the prop variant is setted to 'red'", () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
-				variant: 'variant-3',
+				variant: 'red',
 				content: 'Test',
 			},
 		});
 
-		expect(wrapper.vm.predefinedStyle).toBe('variant-3');
+		expect(wrapper.vm.predefinedStyle).toBe('red');
 	});
 
-	test("if the computed property changes when the prop variant is setted to 'variant-4'", () => {
+	test("if the computed property changes when the prop variant is setted to 'blue'", () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
-				variant: 'variant-4',
+				variant: 'blue',
 				content: 'Test',
 			},
 		});
 
-		expect(wrapper.vm.predefinedStyle).toBe('variant-4');
+		expect(wrapper.vm.predefinedStyle).toBe('blue');
 	});
 
-	test("if the computed property changes when the prop variant is setted to 'variant-5'", () => {
+	test("if the computed property changes when the prop variant is setted to 'purple'", () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
-				variant: 'variant-5',
+				variant: 'purple',
 				content: 'Test',
 			},
 		});
 
-		expect(wrapper.vm.predefinedStyle).toBe('variant-5');
+		expect(wrapper.vm.predefinedStyle).toBe('purple');
 	});
 
-	test("if the computed property changes when the prop variant is setted to 'variant-6'", () => {
+	test("if the computed property changes when the prop variant is setted to 'gray'", () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
-				variant: 'variant-6',
+				variant: 'gray',
 				content: 'Test',
 			},
 		});
 
-		expect(wrapper.vm.predefinedStyle).toBe('variant-6');
+		expect(wrapper.vm.predefinedStyle).toBe('gray');
 	});
 });
 

--- a/test/unit/Badge.spec.js
+++ b/test/unit/Badge.spec.js
@@ -101,15 +101,19 @@ describe("Prop 'variant' tests", () => {
 	});
 });
 
-	test("if the computed property changes when the prop status_type is setted to 'neutral'", () => {
+describe("Prop 'bgColor' and 'color' tests", () => {
+	test("if the computed property 'styleVariables' changes when the prop 'colorCodeMode' is setted to 'true'", () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
-				status_type: 'Neutral',
+				colorCodeMode: true,
+				variantMode: false,
+				color: 'white',
+				bgColor: 'blue',
 				content: 'Test',
 			},
 		});
 
-		expect(wrapper.vm.style).toBe('neutral-badge');
+		expect(wrapper.vm.styleVariables).toStrictEqual({"--bg-color": "blue", "--color": "white"});
 	});
 });

--- a/test/unit/Badge.spec.js
+++ b/test/unit/Badge.spec.js
@@ -15,42 +15,91 @@ test('Component is mounted properly', () => {
 	expect(wrapper).toMatchSnapshot();
 });
 
-describe("Computed property 'style' test", () => {
-	test('if the computed property style works properly with the default value for the prop status_type', () => {
+describe("Computed property 'predefinedStyle' test", () => {
+	test('if the computed property predefinedStyle works properly with the default value for the prop variant', () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
 				content: 'Test',
 			},
 		});
-		expect(wrapper.vm.style).toBe('negative-badge');
+		expect(wrapper.vm.predefinedStyle).toBe('variant-1');
 	});
 });
 
-describe("Prop 'status_type' tests", () => {
-	test("if the computed property changes when the prop status_type is setted to 'negative'", () => {
+describe("Prop 'variant' tests", () => {
+	test("if the computed property changes when the prop variant is setted to 'variant-1'", () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
-				status_type: 'Negative',
+				variant: 'variant-1',
 				content: 'Test',
 			},
 		});
 
-		expect(wrapper.vm.style).toBe('negative-badge');
+		expect(wrapper.vm.predefinedStyle).toBe('variant-1');
 	});
 
-	test("if the computed property changes when the prop status_type is setted to 'positive'", () => {
+	test("if the computed property changes when the prop variant is setted to 'variant-2'", () => {
 		const wrapper = mount(Badge, {
 			localVue,
 			propsData: {
-				status_type: 'Positive',
+				variant: 'variant-2',
 				content: 'Test',
 			},
 		});
 
-		expect(wrapper.vm.style).toBe('positive-badge');
+		expect(wrapper.vm.predefinedStyle).toBe('variant-2');
 	});
+
+	test("if the computed property changes when the prop variant is setted to 'variant-3'", () => {
+		const wrapper = mount(Badge, {
+			localVue,
+			propsData: {
+				variant: 'variant-3',
+				content: 'Test',
+			},
+		});
+
+		expect(wrapper.vm.predefinedStyle).toBe('variant-3');
+	});
+
+	test("if the computed property changes when the prop variant is setted to 'variant-4'", () => {
+		const wrapper = mount(Badge, {
+			localVue,
+			propsData: {
+				variant: 'variant-4',
+				content: 'Test',
+			},
+		});
+
+		expect(wrapper.vm.predefinedStyle).toBe('variant-4');
+	});
+
+	test("if the computed property changes when the prop variant is setted to 'variant-5'", () => {
+		const wrapper = mount(Badge, {
+			localVue,
+			propsData: {
+				variant: 'variant-5',
+				content: 'Test',
+			},
+		});
+
+		expect(wrapper.vm.predefinedStyle).toBe('variant-5');
+	});
+
+	test("if the computed property changes when the prop variant is setted to 'variant-6'", () => {
+		const wrapper = mount(Badge, {
+			localVue,
+			propsData: {
+				variant: 'variant-6',
+				content: 'Test',
+			},
+		});
+
+		expect(wrapper.vm.predefinedStyle).toBe('variant-6');
+	});
+});
 
 	test("if the computed property changes when the prop status_type is setted to 'neutral'", () => {
 		const wrapper = mount(Badge, {

--- a/test/unit/__snapshots__/Badge.spec.js.snap
+++ b/test/unit/__snapshots__/Badge.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component is mounted properly 1`] = `
-<div class="badge-container px-3 d-flex justify-content-center variant-1"><small class="regular">
+<div class="badge-container px-3 d-flex justify-content-center yellow"><small class="regular">
     Test
   </small></div>
 `;

--- a/test/unit/__snapshots__/Badge.spec.js.snap
+++ b/test/unit/__snapshots__/Badge.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component is mounted properly 1`] = `
-<div class="badge-container px-3 d-flex justify-content-center negative-badge"><small class="regular">
+<div class="badge-container px-3 d-flex justify-content-center variant-1"><small class="regular">
     Test
   </small></div>
 `;


### PR DESCRIPTION
#### What is the purpose of this pull request?
The purpose of this pull request is to enhance the functionality of the badge, adding support to new predefined badge styles and allowing the user to pass a specific background color and text color to the component.

#### How should this be manually tested?
* Use the knobs to change the badge predefined styles;
* Change the mode to colorCode and sets variantMode to false and pass hex color codes
   in order to change the background color and the text color of the badge;
* Verify if the predefined styles of the badge passes the accessibility tests

#### Types of changes
- [x]  New feature (a change which adds functionality)
- [ ] Hot fix (a change which fixes an issue found in the master branch)
- [ ]  Documentation change