### PR TITLE
Update dependencies, remove vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/component-library",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "",
   "main": "dist/@sysvale/component-library.ssr.js",
   "module": "dist/@sysvale/component-library.esm.js",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "@storybook/addon-knobs": "^5.3.7",
     "babel-plugin-require-context-hook": "^1.0.0",
     "bootstrap": "^4.4.1",
-    "bootstrap-vue": "^2.2.2",
+    "bootstrap-vue": "^2.8.0",
     "vue-feather-icons": "^5.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.3",
+    "@babel/core": "^7.9.0",
     "@rollup/plugin-alias": "^2.2.0",
     "@rollup/plugin-buble": "^0.20.0",
     "@rollup/plugin-replace": "^2.3.0",
@@ -43,7 +43,7 @@
     "@vue/eslint-config-airbnb": "^4.0.0",
     "@vue/test-utils": "^1.0.0-beta.31",
     "babel-eslint": "^10.1.0",
-    "babel-loader": "^8.0.6",
+    "babel-loader": "^8.1.0",
     "babel-preset-vue": "^2.0.2",
     "cross-env": "^6.0.3",
     "eslint": "^5.16.0",
@@ -62,7 +62,7 @@
     "storybook-addon-designs": "^5.2.0",
     "vue": "^2.6.11",
     "vue-jest": "^3.0.5",
-    "vue-loader": "^15.8.3",
+    "vue-loader": "^15.9.1",
     "vue-template-compiler": "^2.6.11"
   },
   "engines": {


### PR DESCRIPTION
Related to #32 

```
found 37481 low severity vulnerabilities in 1835258 scanned packages
  run `npm audit fix` to fix 36324 of them.
  378 vulnerabilities require semver-major dependency updates.
  779 vulnerabilities require manual review. See the full report for details.
```