### PR TITLE
feature/adds-a-direction-option-to-the-radio-button-group

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sysvale/component-library",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "",
   "main": "dist/@sysvale/component-library.ssr.js",
   "module": "dist/@sysvale/component-library.esm.js",

--- a/src/components/RadioButtonGroup.vue
+++ b/src/components/RadioButtonGroup.vue
@@ -1,12 +1,12 @@
 <template>
 	<span id="radioButton">
 		<div
-			:class="{'d-flex': row }"
+			:class="{'d-flex': inline }"
 		>
 			<div
 				v-for="option in options"
 				:key="option.id"
-				:class="{'ml-3': row }"
+				:class="{'ml-3': inline }"
 			>
 				<label
 					class="radio-button-container"
@@ -53,14 +53,7 @@ export default {
 			description: 'Used to control the availability of the RadioButton.',
 			required: false,
 		},
-		column: {
-			type: Boolean,
-			default: true,
-			description: `The default direction option. When true, the radio buttons will be
-				displayed in a column.`,
-			required: false,
-		},
-		row: {
+		inline: {
 			type: Boolean,
 			default: false,
 			description: `When true, the radio buttons will be displayed in a row.`,

--- a/src/components/RadioButtonGroup.vue
+++ b/src/components/RadioButtonGroup.vue
@@ -140,7 +140,7 @@ export default {
 }
 
 #radioButton .radio-button-container:hover {
-	background-color: rgba(248, 249, 250, 0.75);
+	background-color: rgba(235, 242, 249, 0.5);
 	-webkit-transition: all 0.3s ease;
 	transition: all 0.3s ease;
 }

--- a/src/components/RadioButtonGroup.vue
+++ b/src/components/RadioButtonGroup.vue
@@ -1,17 +1,33 @@
 <template>
 	<span id="radioButton">
 		<div
-			v-for="option in options"
-			:key="option.id"
+			:class="{'d-flex': row }"
 		>
-			<label
-				class="radio-button-container"
-				:disabled="option.disabled || disabled"
-				:for="option.id"
+			<div
+				v-for="option in options"
+				:key="option.id"
+				:class="{'ml-3': row }"
 			>
-				<input type="radio" :id="option.id" :value="option.id" v-model="selected" :disabled="option.disabled || disabled">
-				<label class="m-0" :for="option.id">{{ option.text }}</label>
-			</label>
+				<label
+					class="radio-button-container"
+					:disabled="option.disabled || disabled"
+					:for="option.id"
+				>
+					<input
+						type="radio"
+						:id="option.id"
+						:value="option.id"
+						v-model="selected"
+						:disabled="option.disabled || disabled"
+					>
+					<label
+						class="m-0"
+						:for="option.id"
+					>
+						{{ option.text }}
+					</label>
+				</label>
+			</div>
 		</div>
 	</span>
 </template>
@@ -37,6 +53,19 @@ export default {
 			description: 'Used to control the availability of the RadioButton.',
 			required: false,
 		},
+		column: {
+			type: Boolean,
+			default: true,
+			description: `The default direction option. When true, the radio buttons will be
+				displayed in a column.`,
+			required: false,
+		},
+		row: {
+			type: Boolean,
+			default: false,
+			description: `When true, the radio buttons will be displayed in a row.`,
+			required: false,
+		}
 	},
 	
 	data() {

--- a/src/stories/RadioButtonGroup.stories.js
+++ b/src/stories/RadioButtonGroup.stories.js
@@ -14,8 +14,7 @@ const template = `
 			v-model="value"
 			:options="options"
 			:disabled="disabled"
-			:column="column"
-			:row="row"
+			:inline="inline"
 		/>
 	</div>
 	`;
@@ -103,11 +102,8 @@ export const radioButtonGroup = () => ({
 		disabled: {
 			default: () => boolean('Disabled:', false),
 		},
-		row: {
-			default: () => boolean('Display in a row:', false),
-		},
-		column: {
-			default: () => boolean('Display in a column:', true),
+		inline: {
+			default: () => boolean('Inline:', false),
 		},
 	},
 	template,

--- a/src/stories/RadioButtonGroup.stories.js
+++ b/src/stories/RadioButtonGroup.stories.js
@@ -14,6 +14,8 @@ const template = `
 			v-model="value"
 			:options="options"
 			:disabled="disabled"
+			:column="column"
+			:row="row"
 		/>
 	</div>
 	`;
@@ -100,6 +102,12 @@ export const radioButtonGroup = () => ({
 		},
 		disabled: {
 			default: () => boolean('Disabled:', false),
+		},
+		row: {
+			default: () => boolean('Display in a row:', false),
+		},
+		column: {
+			default: () => boolean('Display in a column:', true),
 		},
 	},
 	template,

--- a/test/unit/__snapshots__/RadioButtonGroup.spec.js.snap
+++ b/test/unit/__snapshots__/RadioButtonGroup.spec.js.snap
@@ -1,3 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component is mounted properly 1`] = `<span id="radioButton"><div><label disabled="disabled" for="id1" class="radio-button-container"><input type="radio" id="id1" disabled="disabled" value="id1"> <label for="id1" class="m-0">Component1</label></label></div><div><label for="id2" class="radio-button-container"><input type="radio" id="id2" value="id2"> <label for="id2" class="m-0">Component2</label></label></div><div><label for="id3" class="radio-button-container"><input type="radio" id="id3" value="id3"> <label for="id3" class="m-0">Component3</label></label></div></span>`;
+exports[`Component is mounted properly 1`] = `
+<span id="radioButton"><div class=""><div class=""><label disabled="disabled" for="id1" class="radio-button-container"><input type="radio" id="id1" disabled="disabled" value="id1"> <label for="id1" class="m-0">
+					Component1
+				</label></label></div><div class=""><label for="id2" class="radio-button-container"><input type="radio" id="id2" value="id2"> <label for="id2" class="m-0">
+					Component2
+				</label></label></div><div class=""><label for="id3" class="radio-button-container"><input type="radio" id="id3" value="id3"> <label for="id3" class="m-0">
+					Component3
+				</label></label></div></div></span>
+`;


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds the feature to display the Radio button group horizontally or vertically

#### How should this be manually tested?
- Check if the direction of the radio buttons change when you change the knobs "Display in a row" and "Display in a column"

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/20057968/88406128-9a95df80-cda6-11ea-801f-79df57ba0f11.png)

#### Types of changes
- [x]  New feature (a change which adds functionality)
- [ ] Hot fix (a change which fixes an issue found in the master branch)
- [ ]  Documentation change